### PR TITLE
Replace string template with render function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 var JsBarcode = require('jsbarcode');
 
 var VueBarcode = {
-  template: '<div>' +
-    '<svg class="vue-barcode-element" v-show="valid"></svg>'+
-    '<div v-show="!valid">'+
-      '<slot></slot>'+
-    '</div>'+
-    '</div>',
+   render: function (createElement) {
+    return createElement('div', [
+      createElement('svg', {
+        style: { display: this.valid ? undefined : 'none' },
+        'class': ['vue-barcode-element']
+      }),
+      createElement('div', {
+        style: { display: this.valid ? 'none' : undefined }
+      }, this.$slots.default),
+    ]);
+  },
   props: {
     value: [String, Number],
     format: [String],


### PR DESCRIPTION
Related #13 

When running in a context where templates aren't available (for example: when compiling Vue templates with webpack), vue-barcode cannot be used.

This PR replaces the template string with a hand-written render function. 